### PR TITLE
Use corepack

### DIFF
--- a/.github/workflows/build-upload.yml
+++ b/.github/workflows/build-upload.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
+    - run: corepack enable
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:


### PR DESCRIPTION
Builds have been broken for the past ~2 weeks since a new version of yarn added validation on the package file. Always enable corepack before doing anything in actions.